### PR TITLE
fix(deps): force patched postcss >=8.5.10 for CVE-2026-41305

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: '>=8.5.10'
+
 importers:
 
   .:
@@ -678,8 +681,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   property-information@7.2.0:
@@ -1485,7 +1488,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.33
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
@@ -1505,7 +1508,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  postcss@8.4.31:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 onlyBuiltDependencies:
   - sharp
   - unrs-resolver
+
+# Force a patched postcss (transitive via next) for CVE-2026-41305.
+overrides:
+  postcss: ">=8.5.10"


### PR DESCRIPTION
## Summary
Resolves Dependabot alert #41 (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305) — postcss XSS via unescaped `</style>` in CSS stringify output.

`postcss@8.4.31` is pulled in **transitively** via `next@16.2.7`. Added a pnpm `overrides` entry in `pnpm-workspace.yaml` to force a patched `>=8.5.10` (resolves to `8.5.15`).

## Risk
Practical exposure is negligible — postcss only processes the author's own CSS at build time, never user-submitted CSS embedded in `<style>` tags — but this clears the alert.

## Verification
- `pnpm why postcss` → `8.5.15`
- `pnpm run lint` clean, `pnpm build` compiles + static-exports successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)